### PR TITLE
Filter out Pushover notifications from Singapore

### DIFF
--- a/src/components/push-notification.js
+++ b/src/components/push-notification.js
@@ -18,15 +18,19 @@ const isBot = (userAgent) => {
   return botPatterns.some(pattern => userAgent.match(pattern));
 };
 
-const getCountryFlag = async () => {
+const getCountryInfo = async () => {
   try {
     const response = await fetch("https://ipapi.co/json/");
     const data = await response.json();
-    return data.country_code ? `${String.fromCodePoint(...data.country_code.toUpperCase().split("").map(char => char.charCodeAt(0) + 127397))} ` : "";
+    const flag = data.country_code ? `${String.fromCodePoint(...data.country_code.toUpperCase().split("").map(char => char.charCodeAt(0) + 127397))} ` : "";
+    return { flag, countryCode: data.country_code || "" };
   } catch (error) {
-    return "";
+    return { flag: "", countryCode: "" };
   }
 };
+
+// Countries to filter out (no notifications)
+const FILTERED_COUNTRIES = ["SG"]; // Singapore
 
 const pushNotification = async (content = null) => {
   if (
@@ -37,7 +41,13 @@ const pushNotification = async (content = null) => {
   )
     return null;
 
-  const flag = await getCountryFlag();
+  const { flag, countryCode } = await getCountryInfo();
+  
+  // Skip notifications from filtered countries
+  if (FILTERED_COUNTRIES.includes(countryCode)) {
+    return null;
+  }
+
   const message = content || `New visitor from ${flag} ${window.location.pathname}`;
 
   const formData = new FormData();


### PR DESCRIPTION
Filters out visitor notifications from Singapore.

**Changes:**
- Renamed `getCountryFlag` to `getCountryInfo` to return both flag and country code
- Added `FILTERED_COUNTRIES` array (currently just 'SG')
- Skip sending notification if visitor is from a filtered country

Easy to add more countries to filter in the future by adding to the array.